### PR TITLE
encoding consistency on different python versions [WIP]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "pypy"
 install:
   - "make reqs"
 script:

--- a/test/test_codec.py
+++ b/test/test_codec.py
@@ -176,3 +176,19 @@ class PolylineCodecTestCase(unittest.TestCase):
             100 * okays / float(waypoints),
             waypoints,
             round(waypoints / patience, 0)))
+
+
+    def test_encode_py35valid(self):
+        e = polyline.encode([
+            (-112.084004, 36.05322),
+            (-112.083914, 36.053573),
+            (-112.083965, 36.053845)])
+        self.assertEqual(e, '~kbkTss`{EQeAHw@')
+
+
+    def test_encode_py27valid(self):
+        e = polyline.encode([
+            (-112.084004, 36.05322),
+            (-112.083914, 36.053573),
+            (-112.083965, 36.053845)])
+        self.assertEqual(e, '~kbkTss`{EQeAJw@')


### PR DESCRIPTION
This PR adds two tests, one of which will fail on every build. Which one fails depends on the python version.

TODO: make these consistent across python versions and remove the test with the "bad" result

@frederickjansen I could use your help in identifying the causes of this bug.

 