### PR TITLE
Parse version without importing at setup time

### DIFF
--- a/polyline/__init__.py
+++ b/polyline/__init__.py
@@ -1,6 +1,6 @@
 from .codec import PolylineCodec
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'
 
 
 def decode(expression, precision=5):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,15 @@
 import os
 
 from codecs import open
-from polyline import __version__
+
+# Parse the version from the module without importing
+with open('polyline/__init__.py') as f:
+    for line in f:
+        if line.find("__version__") >= 0:
+            version = line.split("=")[1].strip()
+            version = version.strip('"')
+            version = version.strip("'")
+            continue
 
 try:
     from setuptools import setup
@@ -21,7 +29,7 @@ with open(os.path.join('requirements', 'test.txt'), 'r') as f:
 
 setup(
     name='polyline',
-    version=__version__,
+    version=version,
     description=desc,
     long_description=long_desc,
     author='Bruno M. Custódio',

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,8 @@ from codecs import open
 with open('polyline/__init__.py') as f:
     for line in f:
         if line.find("__version__") >= 0:
-            version = line.split("=")[1].strip()
-            version = version.strip('"')
-            version = version.strip("'")
-            continue
+            version = line.split("=")[1].strip().strip('"').strip("'")
+            break
 
 try:
     from setuptools import setup


### PR DESCRIPTION
@frederickjansen We ran into an issue of failing installs on some machines. Importing polyline in it's own setup.py is the culprit since it fails if `six` is not installed beforehand.

This PR manually parses the `__init__.py` file to extract the version at setup time.